### PR TITLE
Update pycore_runtime.h: fix typo

### DIFF
--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -264,7 +264,7 @@ typedef struct pyruntimestate {
        a pointer type.
        */
 
-    /* PyInterpreterState.interpreters.main */
+    /* _PyRuntimeState.interpreters.main */
     PyInterpreterState _main_interpreter;
 
 #if defined(__EMSCRIPTEN__) && defined(PY_CALL_TRAMPOLINE)


### PR DESCRIPTION
`_main_interpreter` filed of _PyRuntimeState should be connected with `_PyRuntimeState.interpreters.main` instead of `PyInterpreterState.interpreters.main`. Struct `PyInterpreterState` does not have a `interpreters` filed.